### PR TITLE
fix : 로그인 요청 api 인증 인가 없이 접근하도록 수정

### DIFF
--- a/src/main/java/kr/kernel360/anabada/global/config/SecurityConfig.java
+++ b/src/main/java/kr/kernel360/anabada/global/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
 		httpSecurity.authorizeRequests()
 			.antMatchers(
 				"/auth/login.html",
+				"/api/v1/authenticate",
 				"/"
 			).permitAll()
 			.anyRequest().authenticated()


### PR DESCRIPTION
- 스프링시큐리티 설정 파일에서 인증 인가 검증없이 접근 가능한 uri목록에 로그인 요청 API를 추가했습니다.