### PR TITLE
bug : 닉네임, 이메일 중복체크

### DIFF
--- a/src/main/resources/static/auth/signup.html
+++ b/src/main/resources/static/auth/signup.html
@@ -110,6 +110,7 @@
                     error: function () {
                         $("#email-feedback").text("사용할 수 없는 이메일 입니다.");
                         $("#email-feedback").show();
+                        $("#email").val("");
                     }
                 });
             });
@@ -137,6 +138,7 @@
                     error: function () {
                         $("#nickname-feedback").text("사용할 수 없는 닉네임 입니다.");
                         $("#nickname-feedback").show();
+                        $("#nickname").val("");
                     }
                 });
             });


### PR DESCRIPTION
- 닉네임, 이메일 중복체크 후 중복된 값이 있을경우 에러메시지만 출력되고 입력창이 초기화 되지않아 중복된 닉네임 및 이메일로 회원가입이 가능했던 버그를 수정하였습니다.
- 중복발생 후 닉네임 또는 이메일 입력란을 초기화 하도록 수정하였습니다.