### PR TITLE
feat : Kakao Map API 호출 (좌표를 행정구역 법정동으로 변환하는 API)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
     compileOnly 'org.projectlombok:lombok'
 
@@ -49,4 +50,14 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+ext {
+    set('springCloudVersion', "2021.0.4")
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }

--- a/src/main/java/kr/kernel360/anabada/E2e1AnabadaApplication.java
+++ b/src/main/java/kr/kernel360/anabada/E2e1AnabadaApplication.java
@@ -2,9 +2,11 @@ package kr.kernel360.anabada;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
+@EnableFeignClients
 @SpringBootApplication
 public class E2e1AnabadaApplication {
 

--- a/src/main/java/kr/kernel360/anabada/domain/place/dto/PlaceDto.java
+++ b/src/main/java/kr/kernel360/anabada/domain/place/dto/PlaceDto.java
@@ -2,13 +2,17 @@ package kr.kernel360.anabada.domain.place.dto;
 
 
 import kr.kernel360.anabada.domain.place.entity.Place;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class PlaceDto {
 	private String state;
 
@@ -21,6 +25,14 @@ public class PlaceDto {
 			.state(placeDto.state)
 			.city(placeDto.city)
 			.address1(placeDto.address1)
+			.build();
+	}
+
+	public static PlaceDto of(PlaceResponse placeResponse) {
+		return PlaceDto.builder()
+			.state(placeResponse.getRegion1depthName())
+			.city(placeResponse.getRegion2depthName())
+			.address1(placeResponse.getRegion3depthName())
 			.build();
 	}
 }

--- a/src/main/java/kr/kernel360/anabada/domain/place/dto/PlaceResponse.java
+++ b/src/main/java/kr/kernel360/anabada/domain/place/dto/PlaceResponse.java
@@ -1,0 +1,37 @@
+package kr.kernel360.anabada.domain.place.dto;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PlaceResponse {
+	private String regionType;
+
+	private String addressName;
+
+	@JsonAlias("region_1depth_name")
+	private String region1depthName;
+
+	@JsonAlias("region_2depth_name")
+	private String region2depthName;
+
+	@JsonAlias("region_3depth_name")
+	private String region3depthName;
+
+	@JsonAlias("region_4depth_name")
+	private String region4depthName;
+
+	private String code;
+
+	private Double x;
+
+	private Double y;
+}

--- a/src/main/java/kr/kernel360/anabada/domain/place/dto/PlaceSearch.java
+++ b/src/main/java/kr/kernel360/anabada/domain/place/dto/PlaceSearch.java
@@ -1,0 +1,16 @@
+package kr.kernel360.anabada.domain.place.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlaceSearch {
+	private String x;
+
+	private String y;
+}

--- a/src/main/java/kr/kernel360/anabada/global/api/KakaoFeignController.java
+++ b/src/main/java/kr/kernel360/anabada/global/api/KakaoFeignController.java
@@ -1,0 +1,49 @@
+package kr.kernel360.anabada.global.api;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kr.kernel360.anabada.domain.place.dto.PlaceDto;
+import kr.kernel360.anabada.domain.place.dto.PlaceResponse;
+import kr.kernel360.anabada.domain.place.dto.PlaceSearch;
+import kr.kernel360.anabada.global.client.KakaoFeignClient;
+import kr.kernel360.anabada.global.dto.KakaoPlaceResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class KakaoFeignController {
+	@Value("${kakao-api-key}")
+	private String apiKey;
+
+	private final KakaoFeignClient kakaoFeignClient;
+
+	@GetMapping("/places/result")
+	public ResponseEntity<PlaceDto> findPlaceByCoordinates(@RequestBody PlaceSearch placeSearch) {
+		String inputCoordinateType = "";
+		String outputCoordinateType = "";
+
+		KakaoPlaceResponse kakaoPlaceResponse = kakaoFeignClient
+			.findPlaceByCoordinates("KakaoAK " + apiKey
+				, placeSearch.getX(), placeSearch.getY()
+				, inputCoordinateType, outputCoordinateType);
+
+		List<PlaceResponse> places = kakaoPlaceResponse.getDocuments();
+
+		PlaceResponse resultResponse = places.stream()
+			.filter(place -> place
+				.getRegionType()
+				.equals("B"))
+			.findFirst()
+			.orElseThrow(() -> new IllegalArgumentException("찾는 지역 정보가 존재하지 않습니다."));
+
+		return ResponseEntity.ok().body(PlaceDto.of(resultResponse));
+	}
+}

--- a/src/main/java/kr/kernel360/anabada/global/client/KakaoFeignClient.java
+++ b/src/main/java/kr/kernel360/anabada/global/client/KakaoFeignClient.java
@@ -1,0 +1,18 @@
+package kr.kernel360.anabada.global.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import kr.kernel360.anabada.global.dto.KakaoPlaceResponse;
+
+@FeignClient(name = "kakaoClient", url = "https://dapi.kakao.com")
+public interface KakaoFeignClient {
+	@GetMapping("/v2/local/geo/coord2regioncode.json")
+	KakaoPlaceResponse findPlaceByCoordinates(@RequestHeader("Authorization") String apiKey,
+		@RequestParam("x") String x, @RequestParam("y") String y,
+		@RequestParam(value = "input_coord", required = false) String inputCoordinateType,
+		@RequestParam(value = "output_coord", required = false) String outputCoordinateType);
+
+}

--- a/src/main/java/kr/kernel360/anabada/global/dto/KakaoPlaceResponse.java
+++ b/src/main/java/kr/kernel360/anabada/global/dto/KakaoPlaceResponse.java
@@ -1,0 +1,27 @@
+package kr.kernel360.anabada.global.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import kr.kernel360.anabada.domain.place.dto.PlaceResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoPlaceResponse {
+	private Meta meta;
+	private List<PlaceResponse> documents;
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+	public static class Meta {
+		private Long totalCount;
+	}
+}

--- a/src/main/resources/application-API-KEY.yml
+++ b/src/main/resources/application-API-KEY.yml
@@ -1,0 +1,1 @@
+kakao-api-key = apiKey

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,9 +22,11 @@ spring:
       access-token-validity-in-seconds: 86_400     # 1일
       refresh-token-validity-in-seconds: 1_209_600  # 2주
 
+  profiles:
+    include: API-KEY
+
 logging.level:
   org.hibernate.SQL: debug
 #  org.hibernate.type: trace
   org.springframework.security: debug
-
 

--- a/src/main/resources/static/auth/login.html
+++ b/src/main/resources/static/auth/login.html
@@ -56,6 +56,15 @@
                     "email": $("#email").val(),
                     "password": $("#password").val()
                 }
+                var latitude, longitude;
+                navigator.geolocation.getCurrentPosition(function (position) {
+                    latitude = position.coords.latitude;
+                    longitude = position.coords.longitude;
+                })
+                var placeParam = {
+                    "x" : latitude + "",
+                    "y" : longitude + ""
+                }
                 $.ajax({
                     url: '/api/v1/auth/authenticate',
                     method: 'POST',
@@ -63,6 +72,19 @@
                     contentType: 'application/json',
                     success: function (data) {
                         localStorage.setItem("accessToken", data.tokenResponse.accessToken);
+                        $.ajax({
+                            url: '/api/v1/places/result/',
+                            method: 'GET',
+                            data: placeParam,
+                            dataType: 'json',
+                            headers: {
+                                'Authorization': 'Bearer ' + localStorage.getItem("accessToken") // 헤더에 토큰 추가
+                            },
+                            success : function (data) {
+                                console.log(data);
+                                localStorage.setItem("address", data.address1);
+                            }
+                        })
                         window.location.href = "/"
                     },
                     error: function () {


### PR DESCRIPTION
* ``Spring Cloud OpenFeign``을 사용한 Kakao Map API 호출입니다.
  * ``KakaoFeignClient``를 ``KakaoFeignController``에서 주입 받아서 사용합니다.  
  * ``KakaoFeignController`` 에서 ``findPlaceByCoordinates``를 통해서 좌표를 행정구역으로 바꿔오고 법정동으로 변환하여 반환합니다.
  * 현재 지역정보가 로그인 화면 html에 남아있는데 이 부분 수정이 필요합니다. (로그인 후 홈 화면으로 갈 때 좌표를 변경하여 회원 로컬 스토리지에 저장하도록)