### PR TITLE
fix : tradeinfo에서 image file 안보이는 문제 해결

### DIFF
--- a/src/main/java/kr/kernel360/anabada/domain/trade/api/TradeController.java
+++ b/src/main/java/kr/kernel360/anabada/domain/trade/api/TradeController.java
@@ -1,7 +1,11 @@
 package kr.kernel360.anabada.domain.trade.api;
 
+import java.net.MalformedURLException;
 import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
+import org.springframework.core.io.UrlResource;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -26,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 public class TradeController {
 	private final TradeService tradeService;
 	private final FileHandler fileHandler;
+	private final Path rootLocation = Paths.get("src/main/resources/static/images");
 
 	@GetMapping("/v1/trades")
 	public ResponseEntity<FindAllTradeResponse> findAll() {
@@ -53,4 +59,20 @@ public class TradeController {
 		URI uri = URI.create("/api/v1/trades/"+savedTradeId);
 		return ResponseEntity.created(uri).build();
 	}
+
+	@ResponseBody
+	@GetMapping("/images/{imageName}")
+	public ResponseEntity<UrlResource> showImage(@PathVariable String imageName) {
+
+		try {
+			Path file = rootLocation.resolve(imageName);
+			UrlResource resource = new UrlResource(file.toUri());
+			return ResponseEntity.ok().body(resource);
+
+		} catch (MalformedURLException e) {
+			throw new RuntimeException(e);
+		}
+	}
 }
+
+

--- a/src/main/java/kr/kernel360/anabada/global/FileHandler.java
+++ b/src/main/java/kr/kernel360/anabada/global/FileHandler.java
@@ -15,22 +15,14 @@ import lombok.extern.slf4j.Slf4j;
 public class FileHandler {
 	public String parseFileInfo(MultipartFile multipartFile) {
 
-		// jpeg, png 파일들만 받아서 처리할 예정
 		String contentType = multipartFile.getContentType();
-		if (!(contentType.contains("image/jpg") || contentType.contains("image/jpeg") || contentType.contains("image/png"))) {
+		if (!(contentType.contains("image/jpeg") || contentType.contains("image/png"))) {
 			return null;
 		}
-
-		// String imageName = System.nanoTime()+"_"+multipartFile.getOriginalFilename();
 		String imageName = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyMMddHH24mmss")) + "_" + multipartFile.getOriginalFilename();
-
-		// 경로를 지정하고 그곳에다가 저장
-
-		String imagePath = "images/";
+		String imagePath = "src/main/resources/static/images";
 		File file = new File(imagePath, imageName).getAbsoluteFile();
 
-
-		// 저장된 파일로 변경하여 이를 보여주기 위함
 		try {
 			multipartFile.transferTo(file);
 		} catch (IOException e) {

--- a/src/main/java/kr/kernel360/anabada/global/config/SecurityConfig.java
+++ b/src/main/java/kr/kernel360/anabada/global/config/SecurityConfig.java
@@ -47,7 +47,8 @@ public class SecurityConfig {
 				"/api/v1/auth/authenticate",
 				"/api/v1/auth/signUp",
 				"/",
-				"/images/**"
+				"/images/**",
+				"/api/images/**"
 			).permitAll()
 			.anyRequest().authenticated()
 

--- a/src/main/resources/application-API-KEY.yml
+++ b/src/main/resources/application-API-KEY.yml
@@ -1,1 +1,1 @@
-kakao-api-key = apiKey
+kakao-api-key :

--- a/src/main/resources/static/trade/tradeInfo.html
+++ b/src/main/resources/static/trade/tradeInfo.html
@@ -105,10 +105,11 @@
                 $('#tradeType').val(data.tradeType);
                 $('#categoryName').val(data.categoryName);
 
-                var $image = $('<img>');
+                var $image = $('<img style="max-width: 400px; max-height: 400px;">');
 
                 if (data.imagePath) {
-                    $image.attr('src', data.imagePath);
+
+                    $image.attr('src', '/api'+ data.imagePath);
                     $image.attr('alt', '이미지');
                     $('#tradeImage').append($image);
                 } else {


### PR DESCRIPTION
* 이미지 파일 업로드 관련 기능 중 tradeinfo화면에서  동적으로 이미지 파일이 보이지 않는 문제를 해결하였습니다
* ``SecurityConfig`` 파일에서 권한 관련 이미지관련 경로 및 api 추가
* ``TradeController`` 에서 이미지 리소스 가져오기를 위한 메서드 추가
