### PR TITLE
feat : 교환요청 별 이미지 경로 분할, 입력 수정 화면 validation 추가

### DIFF
--- a/src/main/java/kr/kernel360/anabada/domain/trade/api/TradeController.java
+++ b/src/main/java/kr/kernel360/anabada/domain/trade/api/TradeController.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -60,17 +59,15 @@ public class TradeController {
 		return ResponseEntity.created(uri).build();
 	}
 
-	@ResponseBody
 	@GetMapping("/images/{imageName}")
 	public ResponseEntity<UrlResource> showImage(@PathVariable String imageName) {
-
 		try {
 			Path file = rootLocation.resolve(imageName);
 			UrlResource resource = new UrlResource(file.toUri());
 			return ResponseEntity.ok().body(resource);
 
 		} catch (MalformedURLException e) {
-			throw new RuntimeException(e);
+			throw new IllegalArgumentException("잘못된 형식의 URL 입니다");
 		}
 	}
 }

--- a/src/main/java/kr/kernel360/anabada/domain/trade/api/TradeController.java
+++ b/src/main/java/kr/kernel360/anabada/domain/trade/api/TradeController.java
@@ -30,7 +30,7 @@ import lombok.RequiredArgsConstructor;
 public class TradeController {
 	private final TradeService tradeService;
 	private final FileHandler fileHandler;
-	private final Path rootLocation = Paths.get("src/main/resources/static/images");
+	private final Path rootLocation = Paths.get("src/main/resources/static/images/trade");
 
 	@GetMapping("/v1/trades")
 	public ResponseEntity<FindAllTradeResponse> findAll() {
@@ -50,7 +50,7 @@ public class TradeController {
 		@RequestParam(value = "imageFile", required = false) MultipartFile imageFile) {
 
 		if (imageFile != null && !imageFile.isEmpty()) {
-			String imagePath = fileHandler.parseFileInfo(imageFile);
+			String imagePath = fileHandler.parseFileInfo(imageFile,"trade");
 			createTradeRequest.setImagePath(imagePath);
 		}
 
@@ -59,7 +59,7 @@ public class TradeController {
 		return ResponseEntity.created(uri).build();
 	}
 
-	@GetMapping("/images/{imageName}")
+	@GetMapping("/images/trade/{imageName}")
 	public ResponseEntity<UrlResource> showImage(@PathVariable String imageName) {
 		try {
 			Path file = rootLocation.resolve(imageName);

--- a/src/main/java/kr/kernel360/anabada/domain/tradeoffer/api/TradeOfferController.java
+++ b/src/main/java/kr/kernel360/anabada/domain/tradeoffer/api/TradeOfferController.java
@@ -1,14 +1,20 @@
 package kr.kernel360.anabada.domain.tradeoffer.api;
 
+import java.net.MalformedURLException;
 import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
+import org.springframework.core.io.UrlResource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -16,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import kr.kernel360.anabada.domain.tradeoffer.dto.CreateTradeOfferRequest;
 import kr.kernel360.anabada.domain.tradeoffer.dto.FindAllTradeOfferRequest;
@@ -23,6 +30,7 @@ import kr.kernel360.anabada.domain.tradeoffer.dto.FindTradeOfferResponse;
 import kr.kernel360.anabada.domain.tradeoffer.dto.UpdateTradeOfferRequest;
 import kr.kernel360.anabada.domain.tradeoffer.dto.UpdateTradeOfferResponse;
 import kr.kernel360.anabada.domain.tradeoffer.service.TradeOfferService;
+import kr.kernel360.anabada.global.FileHandler;
 import kr.kernel360.anabada.global.commons.domain.TradeOfferSearchType;
 import lombok.RequiredArgsConstructor;
 
@@ -31,6 +39,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TradeOfferController {
 	private final TradeOfferService tradeOfferService;
+	private final FileHandler fileHandler;
+	private final Path rootLocation = Paths.get("src/main/resources/static/images/tradeOffer");
+
 
 	@GetMapping("/v1/trade-offers")
 	public ResponseEntity<Page<FindTradeOfferResponse>> findAll(
@@ -41,10 +52,18 @@ public class TradeOfferController {
 		return ResponseEntity.ok(tradeOffers);
 	}
 
-	@PostMapping("/v1/trade-offers")
-	public ResponseEntity<Long> create(@RequestBody CreateTradeOfferRequest createTradeOfferRequest) {
+	@PostMapping(path = "/v1/trade-offers", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public ResponseEntity<Long> create(
+		@ModelAttribute CreateTradeOfferRequest createTradeOfferRequest,
+		@RequestParam(value = "imageFile", required = false) MultipartFile imageFile) {
+
+		if (imageFile != null && !imageFile.isEmpty()) {
+			String imagePath = fileHandler.parseFileInfo(imageFile,"tradeOffer");
+			createTradeOfferRequest.setImagePath(imagePath);
+		}
+
 		Long id = tradeOfferService.create(createTradeOfferRequest, createTradeOfferRequest.getTradeId(), createTradeOfferRequest.getMemberId());
-		URI url = URI.create("api/v1/trades/trade_offers" + id);
+		URI url = URI.create("api/v1/trades/trade_offers/" + id);
 		return ResponseEntity.created(url).body(id);
 	}
 
@@ -54,15 +73,27 @@ public class TradeOfferController {
 		return ResponseEntity.ok(updateTradeOfferResponse);
 	}
 
-	@DeleteMapping("v1/trade-offers/{tradeOfferId}")
+	@DeleteMapping("/v1/trade-offers/{tradeOfferId}")
 	public ResponseEntity<Long> remove(@PathVariable Long tradeOfferId) {
 		tradeOfferService.remove(tradeOfferId);
 		return ResponseEntity.ok(tradeOfferId);
 	}
 
-	@GetMapping("v1/trade-offers/{tradeOfferId}")
+	@GetMapping("/v1/trade-offers/{tradeOfferId}")
 	public ResponseEntity<FindTradeOfferResponse> find(@PathVariable Long tradeOfferId) {
 		FindTradeOfferResponse findTradeOfferResponse = tradeOfferService.find(tradeOfferId);
 		return ResponseEntity.ok(findTradeOfferResponse);
+	}
+
+	@GetMapping("/images/tradeOffer/{imageName}")
+	public ResponseEntity<UrlResource> showImage(@PathVariable String imageName) {
+		try {
+			Path file = rootLocation.resolve(imageName);
+			UrlResource resource = new UrlResource(file.toUri());
+			return ResponseEntity.ok().body(resource);
+
+		} catch (MalformedURLException e) {
+			throw new IllegalArgumentException("잘못된 형식의 URL 입니다");
+		}
 	}
 }

--- a/src/main/java/kr/kernel360/anabada/global/FileHandler.java
+++ b/src/main/java/kr/kernel360/anabada/global/FileHandler.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -13,14 +14,14 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Component
 public class FileHandler {
-	public String parseFileInfo(MultipartFile multipartFile) {
-
-		String contentType = multipartFile.getContentType();
+	public String parseFileInfo(MultipartFile multipartFile, String detailPath) {
+		String contentType = Optional.ofNullable(multipartFile.getContentType())
+			.orElseThrow(() -> new IllegalArgumentException("파일 타입을 찾을 수 없습니다."));
 		if (!(contentType.contains("image/jpeg") || contentType.contains("image/png"))) {
 			return null;
 		}
 		String imageName = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyMMddHH24mmss")) + "_" + multipartFile.getOriginalFilename();
-		String imagePath = "src/main/resources/static/images";
+		String imagePath = "src/main/resources/static/images/"+ detailPath;
 		File file = new File(imagePath, imageName).getAbsoluteFile();
 
 		try {
@@ -30,7 +31,7 @@ public class FileHandler {
 			throw new IllegalArgumentException("파일시스템 처리 중 에러가 발생하였습니다.");
 		}
 
-		return "/images/"+imageName;
+		return "/images/" + detailPath + "/" + imageName;
 	}
 
 }

--- a/src/main/resources/static/assets/css/style.css
+++ b/src/main/resources/static/assets/css/style.css
@@ -16,6 +16,14 @@
 .table-list {
   cursor: pointer;
 }
+
+.required-star {
+  color: red !important;
+  margin-left: 5px;
+  font-size: 16px;
+  font-weight: bolder;
+}
+
 /*--------------------------------------------------------------
 # General
 --------------------------------------------------------------*/

--- a/src/main/resources/static/faq/faqCreateForm.html
+++ b/src/main/resources/static/faq/faqCreateForm.html
@@ -19,7 +19,7 @@
                     <form id="faqCreateForm">
                         <div class="row mb-3"></div>
                         <div class="row mb-3">
-                            <label for="faqTitle" class="col-sm-2 col-form-label">제목</label>
+                            <label for="faqTitle" class="col-sm-2 col-form-label">제목<span class="required-star">*</span></label>
                             <div class="col-sm-10">
                                 <input type="text" class="form-control" id="faqTitle" name="faqTitle" required>
                             </div>
@@ -62,6 +62,10 @@
         $('#faqCreateButton').click(function () {
             event.preventDefault();
 
+            if ("" == $('#faqTitle').val()) {
+                alert("제목은 필수입니다.");
+                return;
+            }
             var param = {
                 "title": $('#faqTitle').val(),
                 "content": $('#faqContent').val(),

--- a/src/main/resources/static/faq/faqUpdateForm.html
+++ b/src/main/resources/static/faq/faqUpdateForm.html
@@ -30,8 +30,12 @@
     }
 
     function fn_setEvent() {
-        $('#faqUpdateButton').click(function () {
-            event.preventDefault();
+        $('#faqUpdateButton').click(function (e) {
+            e.preventDefault();
+            if ("" == $('#faqTitle').val()) {
+                alert("제목은 필수입니다.");
+                return;
+            }
             var formData = {
                 "faqId": param.faqId,
                 "title": $('#faqTitle').val(),
@@ -46,7 +50,7 @@
                     'Authorization': 'Bearer ' + localStorage.getItem("accessToken") // 헤더에 토큰 추가
                 },
                 success: function (data) {
-                    authorize('/faq/faqInfo.html?faqId='+param.faqId);
+                    authorize('/faq/faqInfo.html?faqId=' + param.faqId);
                 },
                 error: function () {
                     console.log("fail : faq 수정")
@@ -77,7 +81,7 @@
                     <form id="faqCreateForm">
                         <div class="row mb-3"></div>
                         <div class="row mb-3">
-                            <label for="faqTitle" class="col-sm-2 col-form-label">제목</label>
+                            <label for="faqTitle" class="col-sm-2 col-form-label">제목<span class="required-star">*</span></label>
                             <div class="col-sm-10">
                                 <input type="text" class="form-control" id="faqTitle" name="faqTitle" required>
                             </div>

--- a/src/main/resources/static/trade/tradeCreateForm.html
+++ b/src/main/resources/static/trade/tradeCreateForm.html
@@ -28,13 +28,13 @@
                             </div>
                         </div>
                         <div class="row mb-3">
-                            <label for="shareItem" class="col-sm-2 col-form-label">나눌물건</label>
+                            <label for="shareItem" class="col-sm-2 col-form-label">나눌물건<span class="required-star">*</span></label>
                             <div class="col-sm-10">
                                 <input type="text" class="form-control" id="shareItem" name="shareItem" required>
                             </div>
                         </div>
                         <div id="receiveItemField" class="row mb-3" style="display: none">
-                            <label for="receiveItem" class="col-sm-2 col-form-label">받을물건</label>
+                            <label for="receiveItem" class="col-sm-2 col-form-label">받을물건<span class="required-star">*</span></label>
                             <div class="col-sm-10">
                                 <input type="text" class="form-control" id="receiveItem" name="receiveItem">
                             </div>
@@ -53,7 +53,7 @@
                             </div>
                         </div>
                         <div class="row mb-3">
-                            <label for="tradeType" class="col-sm-2 col-form-label">거래 유형</label>
+                            <label for="tradeType" class="col-sm-2 col-form-label">거래 유형<span class="required-star">*</span></label>
                             <div class="col-sm-10">
                                 <select id="tradeType" name="tradeType" class="form-select"
                                         aria-label="Default select example">
@@ -128,8 +128,16 @@
         });
 
         // "교환 등록" 버튼 클릭 이벤트 핸들러
-        $('#tradeCreateButton').click(function () {
-            event.preventDefault();
+        $('#tradeCreateButton').click(function (e) {
+            e.preventDefault();
+            if ("" == $('#shareItem').val()) {
+                alert("나눌 물건은 필수 입니다.");
+                return;
+            }
+            if ('TRADE' == $('#tradeType').val() && "" == $('#receiveItem').val()) {
+                alert("받을 물건은 필수 입니다.");
+                return;
+            }
             fn_saveTradeInfo();
         });
     }


### PR DESCRIPTION
- 서버에서 교환 등록에서 업로드하는 사진 경로와  교환 요청에서 업로드하는 사진 경로를 분할했습니다.
- 현재 개발되있는 입력, 수정화면에서 필수입력항목에 * 표시를 추가하고 스타일 시트에 필수입력항목 클래스 디자인을 추가하였습니다.
- 현재 개발되있는 입력, 수정화면에서 유효성 검증 기능을 추가했습니다.
- TradeController클래스 showImage메서드에서 불필요한 어노테이션을 제거하고 메서드 내부에서 MalformedURLException 이 발생할 때 RuntimeException이 아니라 IllegalArgumentException으로 메시지를 반환하도록 수정했습니다. IllegalArgumentException는 추후 exceptionhandler 처리 시 변경할 예정입니다.