### PR TITLE
refactor : 회원 식별자 jwt에서 가져오도록 전체 수정

### DIFF
--- a/src/main/java/kr/kernel360/anabada/domain/comment/dto/CreateCommentRequest.java
+++ b/src/main/java/kr/kernel360/anabada/domain/comment/dto/CreateCommentRequest.java
@@ -1,6 +1,5 @@
 package kr.kernel360.anabada.domain.comment.dto;
 
-import kr.kernel360.anabada.domain.category.dto.CreateCategoryRequest;
 import kr.kernel360.anabada.domain.comment.entity.Comment;
 import kr.kernel360.anabada.domain.member.entity.Member;
 import kr.kernel360.anabada.domain.trade.entity.Trade;
@@ -14,7 +13,6 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateCommentRequest {
-	private Long memberId;
 	private String content;
 
 	public static Comment toEntity(CreateCommentRequest createCommentRequest, Member member, Trade trade){

--- a/src/main/java/kr/kernel360/anabada/domain/comment/service/CommentService.java
+++ b/src/main/java/kr/kernel360/anabada/domain/comment/service/CommentService.java
@@ -2,6 +2,7 @@ package kr.kernel360.anabada.domain.comment.service;
 
 import java.util.List;
 
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,7 +27,8 @@ public class CommentService {
 
 	@Transactional
 	public Long create(CreateCommentRequest createCommentRequest, Long tradeId) {
-		Member member = memberRepository.findById(createCommentRequest.getMemberId())
+		String findEmailByJwt = SecurityContextHolder.getContext().getAuthentication().getName();
+		Member member = memberRepository.findOneWithAuthoritiesByEmail(findEmailByJwt)
 			.orElseThrow(()-> new IllegalArgumentException("멤버가 존재하지 않습니다"));
 		Trade trade = findTrade(tradeId);
 		Comment savedComment = commentRepository.save(CreateCommentRequest.toEntity(createCommentRequest, member, trade));

--- a/src/main/java/kr/kernel360/anabada/domain/trade/dto/CreateTradeRequest.java
+++ b/src/main/java/kr/kernel360/anabada/domain/trade/dto/CreateTradeRequest.java
@@ -31,8 +31,6 @@ public class CreateTradeRequest {
 
 	private Long categoryId;
 
-	private Long memberId;
-
 	public static Trade toEntity(CreateTradeRequest createTradeRequest, Category category, Member member) {
 		return Trade.builder()
 			.title(createTradeRequest.title)

--- a/src/main/java/kr/kernel360/anabada/domain/trade/service/TradeService.java
+++ b/src/main/java/kr/kernel360/anabada/domain/trade/service/TradeService.java
@@ -2,6 +2,7 @@ package kr.kernel360.anabada.domain.trade.service;
 
 import java.util.List;
 
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,7 +42,10 @@ public class TradeService {
 
 	@Transactional
 	public Long create(CreateTradeRequest createTradeRequest) {
-		Member member = findMemberById(createTradeRequest.getMemberId());
+
+		String findEmailByJwt = SecurityContextHolder.getContext().getAuthentication().getName();
+		Member member = memberRepository.findOneWithAuthoritiesByEmail(findEmailByJwt)
+			.orElseThrow(()-> new IllegalArgumentException("멤버가 존재하지 않습니다"));
 
 		Category category = categoryRepository.findById(createTradeRequest.getCategoryId())
 			.orElseThrow(() -> new IllegalArgumentException("해당하는 카테고리가 없습니다."));
@@ -52,8 +56,4 @@ public class TradeService {
 		return savedTrade.getId();
 	}
 
-	private Member findMemberById(Long memberId) {
-		return memberRepository.findById(memberId)
-			.orElseThrow(() -> new IllegalArgumentException("회원 정보를 찾을 수 없습니다."));
-	}
 }

--- a/src/main/java/kr/kernel360/anabada/domain/tradeoffer/api/TradeOfferController.java
+++ b/src/main/java/kr/kernel360/anabada/domain/tradeoffer/api/TradeOfferController.java
@@ -62,7 +62,7 @@ public class TradeOfferController {
 			createTradeOfferRequest.setImagePath(imagePath);
 		}
 
-		Long id = tradeOfferService.create(createTradeOfferRequest, createTradeOfferRequest.getTradeId(), createTradeOfferRequest.getMemberId());
+		Long id = tradeOfferService.create(createTradeOfferRequest, createTradeOfferRequest.getTradeId());
 		URI url = URI.create("api/v1/trades/trade_offers/" + id);
 		return ResponseEntity.created(url).body(id);
 	}

--- a/src/main/java/kr/kernel360/anabada/domain/tradeoffer/dto/CreateTradeOfferRequest.java
+++ b/src/main/java/kr/kernel360/anabada/domain/tradeoffer/dto/CreateTradeOfferRequest.java
@@ -27,8 +27,6 @@ public class CreateTradeOfferRequest {
 
 	private final DeletedStatus deletedStatus = DeletedStatus.FALSE;
 
-	private Long memberId;
-
 	private Long tradeId;
 
 	public static TradeOffer toEntity(CreateTradeOfferRequest createTradeOfferRequest, Member member, Trade trade) {

--- a/src/main/java/kr/kernel360/anabada/domain/tradeoffer/service/TradeOfferService.java
+++ b/src/main/java/kr/kernel360/anabada/domain/tradeoffer/service/TradeOfferService.java
@@ -2,6 +2,7 @@ package kr.kernel360.anabada.domain.tradeoffer.service;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,8 +47,10 @@ public class TradeOfferService {
 	}
 
 	@Transactional
-	public Long create(CreateTradeOfferRequest createTradeOfferRequest, Long memberId, Long tradeId) {
-		Member member = findMemberById(memberId);
+	public Long create(CreateTradeOfferRequest createTradeOfferRequest, Long tradeId) {
+		String findEmailByJwt = SecurityContextHolder.getContext().getAuthentication().getName();
+		Member member = memberRepository.findOneWithAuthoritiesByEmail(findEmailByJwt)
+			.orElseThrow(()-> new IllegalArgumentException("멤버가 존재하지 않습니다"));
 
 		Trade trade = findTradeById(tradeId);
 

--- a/src/main/resources/static/trade/tradeCreateForm.html
+++ b/src/main/resources/static/trade/tradeCreateForm.html
@@ -207,7 +207,6 @@
         formData.append('imageFile', $('#imageFile')[0].files[0]);
         formData.append("tradeType", $('#tradeType').val());
         formData.append("categoryId", $('#categoryId').val());
-        formData.append("memberId", $('#memberId').val());
 
         for(var pair of formData.entries()){
             console.log(pair[0], pair[1]);


### PR DESCRIPTION
* 회원 정보를 포함하여 저장해야하는 경우 jwt 페이로드의 이메일을 가져와 회원 식별자로 사용하여 회원정보를 포함하여 등록할 수 있도록 전체적으로 수정하였습니다.