### PR TITLE
feat : redis 설정 및 refreshToken 발급 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     compileOnly 'org.projectlombok:lombok'
 

--- a/src/main/java/kr/kernel360/anabada/domain/auth/dto/TokenResponse.java
+++ b/src/main/java/kr/kernel360/anabada/domain/auth/dto/TokenResponse.java
@@ -11,4 +11,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class TokenResponse {
 	private String accessToken;
+	private String refreshToken;
 }

--- a/src/main/java/kr/kernel360/anabada/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/kr/kernel360/anabada/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,33 @@
+package kr.kernel360.anabada.domain.auth.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RedisHash(value = "refreshToken", timeToLive = 60)
+public class RefreshToken {
+	@Id
+	private String refreshToken;
+
+	private String email;
+
+	private LocalDateTime createdDate;
+
+	private LocalDateTime expirationDate;
+
+	@Builder
+	public RefreshToken(String refreshToken, String email, LocalDateTime createdDate, LocalDateTime expirationDate) {
+		this.refreshToken = refreshToken;
+		this.email = email;
+		this.createdDate = createdDate;
+		this.expirationDate = expirationDate;
+	}
+}

--- a/src/main/java/kr/kernel360/anabada/global/config/RedisConfig.java
+++ b/src/main/java/kr/kernel360/anabada/global/config/RedisConfig.java
@@ -1,0 +1,31 @@
+package kr.kernel360.anabada.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+	@Value("${spring.redis.host}")
+	private String host;
+
+	@Value("${spring.redis.port}")
+	private int port;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(host, port);
+	}
+
+	@Bean
+	public RedisTemplate<Object, Object> redisTemplate() {
+		RedisTemplate<Object, Object> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		return redisTemplate;
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,10 @@ spring:
         #        show-sql: true
         format_sql: true
 
+  redis:
+    host: localhost
+    port: 6379
+
   security:
     jwt:
       header: Authorization

--- a/src/main/resources/static/auth/login.html
+++ b/src/main/resources/static/auth/login.html
@@ -63,6 +63,7 @@
                     contentType: 'application/json',
                     success: function (data) {
                         localStorage.setItem("accessToken", data.tokenResponse.accessToken);
+                        localStorage.setItem("refreshToken", data.tokenResponse.refreshToken);
                         window.location.href = "/";
                     },
                     error: function () {


### PR DESCRIPTION
- Spring data redis 의존성을 추가했습니다.
- refreshToken 발급 기능을 구현하였습니다.
- efreshToken 발급 시 redis에 저장하고 화면으로 반환하는 토큰 정보에 refreshToken을 추가하였습니다.
- 로그인 시 발급된 refreshToken을 로컬스토리지에 저장해도록 추가했습니다.