### PR TITLE
feat : access token 재발급 구현

### DIFF
--- a/src/main/java/kr/kernel360/anabada/domain/auth/api/AuthController.java
+++ b/src/main/java/kr/kernel360/anabada/domain/auth/api/AuthController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import kr.kernel360.anabada.domain.auth.dto.LoginRequest;
 import kr.kernel360.anabada.domain.auth.dto.LoginResponse;
 import kr.kernel360.anabada.domain.auth.dto.SignUpRequest;
+import kr.kernel360.anabada.domain.auth.dto.TokenDto;
 import kr.kernel360.anabada.domain.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 
@@ -50,5 +51,11 @@ public class AuthController {
 		Long savedMemberId = authService.signUp(signUpRequest);
 		URI uri =  URI.create("/api//v1/auth/signUp"+savedMemberId);
 		return ResponseEntity.created(uri).build();
+	}
+
+	@PostMapping("/v1/auth/reissue")
+	public ResponseEntity<TokenDto> reissueAccessToken(@RequestBody TokenDto requestTokenDto) {
+		TokenDto responseTokenDto = authService.reissueAccessToken(requestTokenDto);
+		return ResponseEntity.ok().body(responseTokenDto);
 	}
 }

--- a/src/main/java/kr/kernel360/anabada/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/kr/kernel360/anabada/domain/auth/dto/LoginResponse.java
@@ -2,7 +2,6 @@ package kr.kernel360.anabada.domain.auth.dto;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.security.core.GrantedAuthority;
 
@@ -18,9 +17,9 @@ import lombok.NoArgsConstructor;
 public class LoginResponse {
 	private String email;
 	private List<String> roles;
-	private TokenResponse tokenResponse;
+	private TokenDto tokenDto;
 
-	public static LoginResponse of(String email, Collection<? extends GrantedAuthority> authorities, TokenResponse tokenResponse) {
+	public static LoginResponse of(String email, Collection<? extends GrantedAuthority> authorities, TokenDto tokenDto) {
 		List<String> roles = authorities.stream()
 			.map(String::valueOf)
 			.toList();
@@ -28,7 +27,7 @@ public class LoginResponse {
 		return LoginResponse.builder()
 			.email(email)
 			.roles(roles)
-			.tokenResponse(tokenResponse)
+			.tokenDto(tokenDto)
 			.build();
 	}
 }

--- a/src/main/java/kr/kernel360/anabada/domain/auth/dto/TokenDto.java
+++ b/src/main/java/kr/kernel360/anabada/domain/auth/dto/TokenDto.java
@@ -4,12 +4,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class TokenResponse {
+public class TokenDto {
 	private String accessToken;
 	private String refreshToken;
 }

--- a/src/main/java/kr/kernel360/anabada/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/kernel360/anabada/domain/auth/service/AuthService.java
@@ -10,7 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import kr.kernel360.anabada.domain.auth.dto.LoginRequest;
 import kr.kernel360.anabada.domain.auth.dto.LoginResponse;
 import kr.kernel360.anabada.domain.auth.dto.SignUpRequest;
-import kr.kernel360.anabada.domain.auth.dto.TokenResponse;
+import kr.kernel360.anabada.domain.auth.dto.TokenDto;
 import kr.kernel360.anabada.domain.member.entity.Member;
 import kr.kernel360.anabada.domain.member.repository.MemberRepository;
 import kr.kernel360.anabada.global.jwt.TokenProvider;
@@ -36,7 +36,7 @@ public class AuthService {
 		Authentication authentication = authenticationManagerBuilder.getObject()
 			.authenticate(authenticationToken);
 
-		TokenResponse token = tokenProvider.createToken(authentication);
+		TokenDto token = tokenProvider.createToken(authentication);
 
 		return LoginResponse.of(findMember.getEmail(), authentication.getAuthorities(), token);
 	}
@@ -72,4 +72,9 @@ public class AuthService {
 		Member member = memberRepository.save(signUpRequest.toEntity(signUpRequest));
 		return member.getId();
 	}
+
+	public TokenDto reissueAccessToken(TokenDto requestTokenDto) {
+		return tokenProvider.reissueToken(requestTokenDto);
+	}
+
 }

--- a/src/main/java/kr/kernel360/anabada/global/config/RedisConfig.java
+++ b/src/main/java/kr/kernel360/anabada/global/config/RedisConfig.java
@@ -22,8 +22,8 @@ public class RedisConfig {
 	}
 
 	@Bean
-	public RedisTemplate<Object, Object> redisTemplate() {
-		RedisTemplate<Object, Object> redisTemplate = new RedisTemplate<>();
+	public RedisTemplate<String, String> redisTemplate() {
+		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
 		redisTemplate.setConnectionFactory(redisConnectionFactory());
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
 		return redisTemplate;

--- a/src/main/java/kr/kernel360/anabada/global/config/SecurityConfig.java
+++ b/src/main/java/kr/kernel360/anabada/global/config/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
 				"/api/v1/auth/isNicknameUnique",
 				"/api/v1/auth/authenticate",
 				"/api/v1/auth/signUp",
+				"/api/v1/auth/reissue",
 				"/images/**",
 				"/api/images/**"
 			).permitAll()

--- a/src/main/java/kr/kernel360/anabada/global/jwt/JwtFilter.java
+++ b/src/main/java/kr/kernel360/anabada/global/jwt/JwtFilter.java
@@ -26,7 +26,7 @@ public class JwtFilter extends GenericFilterBean {
 		HttpServletRequest httpServletRequest = (HttpServletRequest) request;
 		String jwt = resolveToken(httpServletRequest);
 
-		if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt, request)) {
+		if (StringUtils.hasText(jwt) && tokenProvider.validateAccessToken(jwt, request)) {
 			Authentication authentication = tokenProvider.getAuthentication(jwt);
 			// Security Context에 인증정보 저장
 			SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/resources/static/auth/login.html
+++ b/src/main/resources/static/auth/login.html
@@ -62,8 +62,8 @@
                     data: JSON.stringify(param),
                     contentType: 'application/json',
                     success: function (data) {
-                        localStorage.setItem("accessToken", data.tokenResponse.accessToken);
-                        localStorage.setItem("refreshToken", data.tokenResponse.refreshToken);
+                        localStorage.setItem("accessToken", data.tokenDto.accessToken);
+                        localStorage.setItem("refreshToken", data.tokenDto.refreshToken);
                         window.location.href = "/";
                     },
                     error: function () {

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -54,7 +54,39 @@
                     loadHtmlAndExecuteScript(url, param);
                 },
                 error: function (xhr, status, error) {
-                    alert("로그인 정보가 없거나 권한 정보가 없습니다.") // todo : 추후 exception 별 분기 필요
+                    console.log("토큰에러!");
+                    // 엑세스 토큰 만료
+                    if (null != localStorage.getItem("accessToken")) {
+                        reissueAccessToken(url);
+                    }
+                    // 권한 없이 접근
+                    else {
+                        alert("로그인 정보가 없거나 권한 정보가 없습니다.") // todo : 추후 exception 별 분기 필요
+                    }
+                }
+            });
+        }
+
+        function reissueAccessToken(url) {
+            var json = {
+                "accessToken" : localStorage.getItem("accessToken"),
+                "refreshToken" : localStorage.getItem("refreshToken")
+            }
+
+            $.ajax({
+                url: '/api/v1/auth/reissue',
+                method: 'POST',
+                contentType: 'application/json',
+                dataType: 'json',
+                data : JSON.stringify(json),
+                success: function (data) {
+                    localStorage.setItem("accessToken", data.accessToken);
+                    authorize(url);
+                },
+                error: function (xhr, status, error) {
+                    alert("리플래시 토큰이 만료되었습니다."); // todo : 추후 exception 별 분기 필요
+                    localStorage.clear();
+                    window.location.href = "/auth/login.html";
                 }
             });
         }
@@ -76,7 +108,6 @@
         }
 
         function loadHtmlAndExecuteScript(url, param) {
-            // 단순 페이지 간 파라미터를 전송할 목적인 경우가 있어서 ? 이전으로 삭제함.
             if (url.includes('?'))
                 url = url.substring(0, url.indexOf('?'));
             const allowedUrls = [


### PR DESCRIPTION
- accessToken이 만료되었을 경우 refreshToken을 통해 accessToken를 재발급 하도록 구현했습니다.
- refreshToken가 만료되었을 경우 레디스에서 refreshToken을 삭제하고 로그아웃할 수 있도록 구현했습니다.
- TokenResponse -> TokenDto 클래스명을 변경하였습니다.
- accessToken 재발급 api를 인증인가 필터에서 제외할 수 있도록 시큐티리 설정을 수정하였습니다.