### PR TITLE
feat : tradeOffer 로직 리팩토링, tradeOffer 목록화면, 상세화면 추가

### DIFF
--- a/src/main/java/kr/kernel360/anabada/domain/tradeoffer/api/TradeOfferController.java
+++ b/src/main/java/kr/kernel360/anabada/domain/tradeoffer/api/TradeOfferController.java
@@ -6,10 +6,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.springframework.core.io.UrlResource;
-import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -26,12 +24,12 @@ import org.springframework.web.multipart.MultipartFile;
 
 import kr.kernel360.anabada.domain.tradeoffer.dto.CreateTradeOfferRequest;
 import kr.kernel360.anabada.domain.tradeoffer.dto.FindAllTradeOfferRequest;
+import kr.kernel360.anabada.domain.tradeoffer.dto.FindAllTradeOfferResponse;
 import kr.kernel360.anabada.domain.tradeoffer.dto.FindTradeOfferResponse;
 import kr.kernel360.anabada.domain.tradeoffer.dto.UpdateTradeOfferRequest;
 import kr.kernel360.anabada.domain.tradeoffer.dto.UpdateTradeOfferResponse;
 import kr.kernel360.anabada.domain.tradeoffer.service.TradeOfferService;
 import kr.kernel360.anabada.global.FileHandler;
-import kr.kernel360.anabada.global.commons.domain.TradeOfferSearchType;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -44,11 +42,12 @@ public class TradeOfferController {
 
 
 	@GetMapping("/v1/trade-offers")
-	public ResponseEntity<Page<FindTradeOfferResponse>> findAll(
-		@RequestParam(required = true) TradeOfferSearchType tradeOfferSearchType,
-		@RequestBody FindAllTradeOfferRequest findAllTradeOfferRequest,
-		@PageableDefault(sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
-		Page<FindTradeOfferResponse> tradeOffers = tradeOfferService.findAll(tradeOfferSearchType, findAllTradeOfferRequest, pageable).map(FindTradeOfferResponse::of);
+	public ResponseEntity<FindAllTradeOfferResponse> findAll(
+		FindAllTradeOfferRequest findAllTradeOfferRequest,
+		@RequestParam(value="pageNo", defaultValue="1") int pageNo
+	) {
+		Pageable pageable = PageRequest.of(pageNo<1 ? 0 : pageNo-1, 10);
+		FindAllTradeOfferResponse tradeOffers = tradeOfferService.findAll(findAllTradeOfferRequest, pageable);
 		return ResponseEntity.ok(tradeOffers);
 	}
 
@@ -72,6 +71,13 @@ public class TradeOfferController {
 		UpdateTradeOfferResponse updateTradeOfferResponse = tradeOfferService.update(updateTradeOfferRequest);
 		return ResponseEntity.ok(updateTradeOfferResponse);
 	}
+
+	// todo : 수락버튼 클릭시
+	// @PutMapping("/v1/trade-offers/{tradeOfferId}/accept")
+	// public ResponseEntity<UpdateTradeOfferResponse> accept(@PathVariable Long tradeOfferId) {
+	// 	UpdateTradeOfferResponse updateTradeOfferResponse = tradeOfferService.accept(tradeOfferId);
+	// 	return ResponseEntity.ok(updateTradeOfferResponse);
+	// }
 
 	@DeleteMapping("/v1/trade-offers/{tradeOfferId}")
 	public ResponseEntity<Long> remove(@PathVariable Long tradeOfferId) {

--- a/src/main/java/kr/kernel360/anabada/domain/tradeoffer/dto/FindAllTradeOfferResponse.java
+++ b/src/main/java/kr/kernel360/anabada/domain/tradeoffer/dto/FindAllTradeOfferResponse.java
@@ -1,6 +1,6 @@
 package kr.kernel360.anabada.domain.tradeoffer.dto;
 
-import java.util.List;
+import org.springframework.data.domain.Page;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,9 +14,9 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class FindAllTradeOfferResponse {
-	List<FindTradeOfferDto> tradeOffers;
+	Page<FindTradeOfferDto> tradeOffers;
 
-	public static FindAllTradeOfferResponse of(List<FindTradeOfferDto> tradeOffers) {
+	public static FindAllTradeOfferResponse of(Page<FindTradeOfferDto> tradeOffers) {
 		return FindAllTradeOfferResponse.builder()
 			.tradeOffers(tradeOffers)
 			.build();

--- a/src/main/java/kr/kernel360/anabada/domain/tradeoffer/dto/FindTradeOfferDto.java
+++ b/src/main/java/kr/kernel360/anabada/domain/tradeoffer/dto/FindTradeOfferDto.java
@@ -2,16 +2,18 @@ package kr.kernel360.anabada.domain.tradeoffer.dto;
 
 import java.time.LocalDateTime;
 
-import kr.kernel360.anabada.domain.tradeoffer.entity.TradeOffer;
+import com.querydsl.core.annotations.QueryProjection;
+
 import kr.kernel360.anabada.global.commons.domain.DeletedStatus;
 import kr.kernel360.anabada.global.commons.domain.TradeOfferStatus;
-
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
 public class FindTradeOfferDto {
 		private Long id;
 
@@ -31,20 +33,20 @@ public class FindTradeOfferDto {
 
 		private LocalDateTime createdDate;
 
-	public static FindTradeOfferDto of(TradeOffer tradeOffer) {
-		return FindTradeOfferDto.builder()
-			.id(tradeOffer.getId())
-			.title(tradeOffer.getTitle())
-			.imagePath(tradeOffer.getImagePath())
-			.tradeOfferStatus(tradeOffer.getTradeOfferStatus())
-			.deletedStatus(tradeOffer.getDeletedStatus())
-			.content(tradeOffer.getContent())
-			.createdBy(tradeOffer.getMember().getNickname())
-			.tradeId(tradeOffer.getTrade().getId())
-			.createdDate(tradeOffer.getCreatedDate())
-			.build();
+	@QueryProjection
+	@Builder
+	public FindTradeOfferDto(Long id, String title, TradeOfferStatus tradeOfferStatus, DeletedStatus deletedStatus,
+		String createdBy, Long tradeId, LocalDateTime createdDate) {
+		this.id = id;
+		this.title = title;
+		this.tradeOfferStatus = tradeOfferStatus;
+		this.deletedStatus = deletedStatus;
+		this.createdBy = createdBy;
+		this.tradeId = tradeId;
+		this.createdDate = createdDate;
 	}
 
+	@QueryProjection
 	@Builder
 	public FindTradeOfferDto(Long id, String title, String content, String imagePath, TradeOfferStatus tradeOfferStatus,
 		DeletedStatus deletedStatus, String createdBy, LocalDateTime createdDate, Long tradeId) {

--- a/src/main/java/kr/kernel360/anabada/domain/tradeoffer/dto/FindTradeOfferResponse.java
+++ b/src/main/java/kr/kernel360/anabada/domain/tradeoffer/dto/FindTradeOfferResponse.java
@@ -1,9 +1,5 @@
 package kr.kernel360.anabada.domain.tradeoffer.dto;
 
-import java.time.LocalDateTime;
-
-import kr.kernel360.anabada.global.commons.domain.DeletedStatus;
-import kr.kernel360.anabada.global.commons.domain.TradeOfferStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,35 +12,13 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class FindTradeOfferResponse {
-	private Long id;
+	private FindTradeOfferDto findTradeOfferDto;
 
-	private String title;
-
-	private String content;
-
-	private String imagePath;
-
-	private TradeOfferStatus tradeOfferStatus;
-
-	private DeletedStatus deletedStatus;
-
-	private String createdBy;
-
-	private Long tradeId;
-
-	private LocalDateTime createdDate;
-
+	@Builder
 	public static FindTradeOfferResponse of(FindTradeOfferDto findTradeOfferDto) {
 		return FindTradeOfferResponse.builder()
-			.id(findTradeOfferDto.getId())
-			.title(findTradeOfferDto.getTitle())
-			.content(findTradeOfferDto.getContent())
-			.imagePath(findTradeOfferDto.getImagePath())
-			.tradeOfferStatus(findTradeOfferDto.getTradeOfferStatus())
-			.deletedStatus(findTradeOfferDto.getDeletedStatus())
-			.createdBy(findTradeOfferDto.getCreatedBy())
-			.tradeId(findTradeOfferDto.getTradeId())
-			.createdDate(findTradeOfferDto.getCreatedDate())
+			.findTradeOfferDto(findTradeOfferDto)
 			.build();
 	}
+
 }

--- a/src/main/java/kr/kernel360/anabada/domain/tradeoffer/repository/TradeOfferRepository.java
+++ b/src/main/java/kr/kernel360/anabada/domain/tradeoffer/repository/TradeOfferRepository.java
@@ -1,17 +1,8 @@
 package kr.kernel360.anabada.domain.tradeoffer.repository;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import kr.kernel360.anabada.domain.member.entity.Member;
-import kr.kernel360.anabada.domain.trade.entity.Trade;
 import kr.kernel360.anabada.domain.tradeoffer.entity.TradeOffer;
-import kr.kernel360.anabada.global.commons.domain.DeletedStatus;
 
-public interface TradeOfferRepository extends JpaRepository<TradeOffer, Long> {
-	Page<TradeOffer> findByMemberAndDeletedStatus(Member member, DeletedStatus deletedStatus, Pageable pageable);
-
-	Page<TradeOffer> findByTradeAndDeletedStatus(Trade trade, DeletedStatus deletedStatus, Pageable pageable);
-
+public interface TradeOfferRepository extends JpaRepository<TradeOffer, Long>, TradeOfferRepositoryCustom {
 }

--- a/src/main/java/kr/kernel360/anabada/domain/tradeoffer/repository/TradeOfferRepositoryCustom.java
+++ b/src/main/java/kr/kernel360/anabada/domain/tradeoffer/repository/TradeOfferRepositoryCustom.java
@@ -1,0 +1,13 @@
+package kr.kernel360.anabada.domain.tradeoffer.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import kr.kernel360.anabada.domain.tradeoffer.dto.FindAllTradeOfferRequest;
+import kr.kernel360.anabada.domain.tradeoffer.dto.FindTradeOfferDto;
+
+public interface TradeOfferRepositoryCustom {
+	Page<FindTradeOfferDto> findAll(FindAllTradeOfferRequest findAllTradeOfferRequest, Pageable pageable);
+
+	FindTradeOfferDto find(Long tradeOfferId);
+}

--- a/src/main/java/kr/kernel360/anabada/domain/tradeoffer/repository/TradeOfferRepositoryImpl.java
+++ b/src/main/java/kr/kernel360/anabada/domain/tradeoffer/repository/TradeOfferRepositoryImpl.java
@@ -1,0 +1,87 @@
+package kr.kernel360.anabada.domain.tradeoffer.repository;
+
+import static kr.kernel360.anabada.domain.member.entity.QMember.*;
+import static kr.kernel360.anabada.domain.tradeoffer.entity.QTradeOffer.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import kr.kernel360.anabada.domain.tradeoffer.dto.FindAllTradeOfferRequest;
+import kr.kernel360.anabada.domain.tradeoffer.dto.FindTradeOfferDto;
+import kr.kernel360.anabada.domain.tradeoffer.dto.QFindTradeOfferDto;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TradeOfferRepositoryImpl implements TradeOfferRepositoryCustom{
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Page<FindTradeOfferDto> findAll(FindAllTradeOfferRequest findAllTradeOfferRequest, Pageable pageable) {
+		List<FindTradeOfferDto> content = queryFactory
+			.select(new QFindTradeOfferDto(
+				tradeOffer.id,
+				tradeOffer.title,
+				tradeOffer.tradeOfferStatus,
+				tradeOffer.deletedStatus,
+				member.nickname,
+				tradeOffer.trade.id,
+				tradeOffer.createdDate
+			))
+			.from(tradeOffer)
+			.leftJoin(tradeOffer.member, member)
+			.where(
+				memberIdEq(findAllTradeOfferRequest.getMemberId()),
+				tradeIdEq(findAllTradeOfferRequest.getTradeId())
+				)
+			.orderBy(tradeOffer.id.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		Long total = queryFactory
+			.select(tradeOffer.count())
+			.from(tradeOffer)
+			.leftJoin(tradeOffer.member, member)
+			.where(
+				memberIdEq(findAllTradeOfferRequest.getMemberId()),
+				tradeIdEq(findAllTradeOfferRequest.getTradeId())
+			)
+			.fetchOne();
+
+		return new PageImpl<>(content, pageable, total);
+
+	}
+	private BooleanExpression memberIdEq(Long memberId) {
+		return memberId != null ? member.id.eq(memberId) : null;
+	}
+	private BooleanExpression tradeIdEq(Long tradeId) {
+		return tradeId != null ? tradeOffer.trade.id.eq(tradeId) : null;
+	}
+
+	@Override
+	public FindTradeOfferDto find(Long tradeOfferId) {
+		return queryFactory
+			.select(new QFindTradeOfferDto(
+				tradeOffer.id,
+				tradeOffer.title,
+				tradeOffer.content,
+				tradeOffer.imagePath,
+				tradeOffer.tradeOfferStatus,
+				tradeOffer.deletedStatus,
+				member.nickname,
+				tradeOffer.createdDate,
+				tradeOffer.trade.id
+			))
+			.from(tradeOffer)
+			.leftJoin(tradeOffer.member, member)
+			.where(tradeOffer.id.eq(tradeOfferId))
+			.fetchOne();
+	}
+
+}

--- a/src/main/resources/static/member/memberInfo.html
+++ b/src/main/resources/static/member/memberInfo.html
@@ -225,7 +225,7 @@
 
                 $('.trade-item').click(function () {
                     var tradeId = $(this).data('trade-id');
-                    authorize('/trade/tradeInfo.html?tradeNo='+tradeId);
+                    authorize('/trade/tradeInfo.html?tradeId='+tradeId);
                 });
             },
             error: function () {
@@ -258,7 +258,7 @@
 
                 // $('.trade-item').click(function () {
                 //     var tradeId = $(this).data('trade-id');
-                //     authorize('/trade/tradeInfo.html?tradeNo='+tradeId);
+                //     authorize('/trade/tradeInfo.html?tradeId='+tradeId);
                 // });
             },
             error: function () {

--- a/src/main/resources/static/trade/tradeInfo.html
+++ b/src/main/resources/static/trade/tradeInfo.html
@@ -65,7 +65,11 @@
 
                         <div class="row mb-3">
                             <div class="col-sm-10">
-                                <button id="tradeRequestButton" class="btn btn-primary">거래 요청</button>
+                                <button id="tradeOfferCreateButton" class="btn btn-primary">거래 요청하기</button>
+                            </div>
+
+                            <div class="col-sm-10">
+                                <button id="viewTradeOfferButton" class="btn btn-primary">요청 목록 조회</button>
                             </div>
                         </div>
 
@@ -90,7 +94,7 @@
 
     function getTradeInfo() {
         $.ajax({
-            url: '/api/v1/trades/' + param.tradeNo,
+            url: '/api/v1/trades/' + param.tradeId,
             method: 'GET',
             dataType: 'json',
             headers: {
@@ -125,9 +129,14 @@
 
     function fn_setEvent() {
         // "거래 요청" 버튼을 초기화
-        $('#tradeRequestButton').click(function (e) {
+        $('#tradeOfferCreateButton').click(function (e) {
             e.preventDefault();
-            authorize('/trade/tradeRequestForm.html?tradeNo='+param.tradeNo+'&nickname='+param.nickname+'&tradeTitle='+param.tradeTitle);
+            authorize('/tradeOffer/tradeOfferCreateForm.html?tradeId='+param.tradeId+'&nickname='+param.nickname+'&tradeTitle='+param.tradeTitle);
+        });
+
+        $('#viewTradeOfferButton').click(function (e) {
+            e.preventDefault();
+            authorize('/tradeOffer/tradeOfferList.html?tradeId='+param.tradeId+'&nickname='+param.nickname+'&tradeTitle='+param.tradeTitle);
         });
     }
 </script>

--- a/src/main/resources/static/trade/tradeList.html
+++ b/src/main/resources/static/trade/tradeList.html
@@ -202,7 +202,7 @@
 
                 $('.trade-item').click(function () {
                     var tradeId = $(this).data('trade-id');
-                    authorize('/trade/tradeInfo.html?tradeNo='+tradeId);
+                    authorize('/trade/tradeInfo.html?tradeId='+tradeId);
                 });
             },
             error: function () {

--- a/src/main/resources/static/tradeOffer/tradeOfferCreateForm.html
+++ b/src/main/resources/static/tradeOffer/tradeOfferCreateForm.html
@@ -1,7 +1,7 @@
 <div class="pagetitle">
     <nav>
         <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="/">AnabadA</a></li>
+            <li class="breadcrumb-item"><a href="/static">AnabadA</a></li>
             <li class="breadcrumb-item "><a onclick="authorize('/trade/tradeList.html')">교환</a></li>
             <li class="breadcrumb-item"><a id="infoPageButton">상세조회</a></li>
             <li class="breadcrumb-item active">거래요청</li>
@@ -80,7 +80,7 @@
 
     function fn_setEvent() {
         $('#infoPageButton').click(function () {
-            authorize('/trade/tradeInfo.html?tradeNo=' + param.tradeNo);
+            authorize('/trade/tradeInfo.html?tradeId=' + param.tradeId);
         });
 
         // "요청하기" 버튼 클릭 이벤트 핸들러
@@ -108,12 +108,13 @@
     }
 
     function fn_saveTradeInfo() {
+        console.log("fn_saveTradeInfo");
         var formData = new FormData();
         formData.append("title", $('#requestTitle').val());
         formData.append('imageFile', $('#imageFile')[0].files[0]);
         formData.append("content", $('#requestContent').val());
         formData.append("memberId", 1);
-        formData.append("tradeId", param.tradeNo);
+        formData.append("tradeId", param.tradeId);
 
         for (var pair of formData.entries()) {
             console.log(pair[0], pair[1]);

--- a/src/main/resources/static/tradeOffer/tradeOfferInfo.html
+++ b/src/main/resources/static/tradeOffer/tradeOfferInfo.html
@@ -1,0 +1,133 @@
+<div class="pagetitle">
+    <nav>
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="/static">AnabadA</a></li>
+            <li class="breadcrumb-item "><a onclick="authorize('/trade/tradeList.html')">교환</a></li>
+            <li class="breadcrumb-item"><a id="infoPageButton">교환상세</a></li>
+            <li class="breadcrumb-item"><a id="OfferListPageButton">교환요청</a></li>
+            <li class="breadcrumb-item active">교환요청상세</li>
+        </ol>
+    </nav>
+</div><!-- End Page Title -->
+
+<section class="section">
+    <div class="row">
+        <div class="col-lg-12">
+
+            <div class="card">
+                <div class="card-body" style="padding: 0px 20px !important;">
+                    <div style="display: flex; justify-content: space-between; align-items: center;">
+                        <div style="text-align: left;">
+                            <h5 id="ownerTradeTitle" class="card-title"></h5>
+                        </div>
+                        <div style="text-align: right;">
+                            <span id="ownerNickname" style="font-weight: 600;"></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- General Form Elements -->
+            <form>
+
+                <div class="card">
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col-md-6">
+                                <div>
+                                    <h5 class="card-title">요청 제목</h5>
+                                    <input type="text" class="form-control" id="title" name="title" readonly>
+                                </div>
+                                <div>
+                                    <h5 class="card-title">사진</h5>
+                                    <div class="col-sm-10">
+                                        <div id="tradeImage"></div>
+                                    </div>
+                                </div>
+
+                            </div>
+
+                            <div class="col-md-6">
+                                <h5 class="card-title">요청 내용</h5>
+                                <textarea id="content" name="content" class="form-control"
+                                          style="height: 173px" readonly></textarea>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-sm-10">
+                                <button id="tradeOfferAcceptButton" class="btn btn-primary">요청 수락</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</section>
+
+<script>
+    $(document).ready(function () {
+        fn_init();
+    });
+
+    function fn_init() {
+        fn_setTradeInfo()
+        fn_getTradeOfferInfo();
+        fn_setEvent();
+    }
+
+    function fn_setTradeInfo() {
+        $('#ownerTradeTitle').text(param.tradeTitle)
+        $('#ownerNickname').text(param.nickname)
+    }
+
+    function fn_setEvent() {
+        $('#infoPageButton').click(function () {
+            authorize('/trade/tradeInfo.html?tradeId=' + param.tradeId+'&nickname='+param.nickname+'&tradeTitle='+param.tradeTitle);
+        });
+
+        $('#OfferListPageButton').click(function () {
+            authorize('/tradeOffer/tradeOfferList.html?tradeId='+param.tradeId+'&nickname='+param.nickname+'&tradeTitle='+param.tradeTitle);
+        });
+
+        $('#tradeOfferAcceptButton').click(function () {
+            fn_tradeOfferAccept();
+        });
+
+    }
+
+    function fn_getTradeOfferInfo() {
+        console.log(param.tradeOfferId);
+        $.ajax({
+            url: '/api/v1/trade-offers/' + param.tradeOfferId,
+            method: 'GET',
+            dataType: 'json',
+            headers: {
+                'Authorization': 'Bearer ' + localStorage.getItem("accessToken") // 헤더에 토큰 추가
+            },
+            success: function (data) {
+                console.log(data.content);
+                console.log(data);
+                $('#title').val(data.findTradeOfferDto.title);
+                $('#content').val(data.findTradeOfferDto.content);
+
+
+                var $image = $('<img style="max-width: 400px; max-height: 400px;">');
+
+                if (data.findTradeOfferDto.imagePath) {
+                    $image.attr('src', '/api'+ data.findTradeOfferDto.imagePath);
+                    $image.attr('alt', '이미지');
+                    $('#tradeImage').append($image);
+                } else {
+                    $('#tradeImage').append("", $('#image').val())
+                }
+            },
+            error: function () {
+                console.log('fail : tradeOffer 상세 조회');
+            }
+        });
+    }
+
+
+</script>
+

--- a/src/main/resources/static/tradeOffer/tradeOfferList.html
+++ b/src/main/resources/static/tradeOffer/tradeOfferList.html
@@ -1,0 +1,196 @@
+
+<div class="pagetitle">
+    <nav>
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="/">AnabadA</a></li>
+            <li class="breadcrumb-item "><a onclick="authorize('/trade/tradeList.html')">교환</a></li>
+            <li class="breadcrumb-item"><a id="infoPageButton">교환상세</a></li>
+            <li class="breadcrumb-item active">교환요청</li>
+        </ol>
+    </nav>
+</div>
+
+
+<section class="section">
+    <div class="row">
+        <div class="col-lg-12">
+
+            <div class="card">
+                <div class="card-body" style="padding: 0px 20px !important;">
+                    <div style="display: flex; justify-content: space-between; align-items: center;">
+                        <div style="text-align: left;">
+                            <h5 id="ownerTradeTitle" class="card-title"></h5>
+                        </div>
+                        <div style="text-align: right;">
+                            <span id="ownerNickname" style="font-weight: 600;"></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card">
+                <div class="card-body">
+                    <div>
+                        교환 요청 리스트
+                    </div>
+
+                    <div class="card">
+                        <div class="card-body" style="padding: 10px 20px 10px 20px;">
+
+                            <table class="table align-middle">
+                                <thead>
+                                <tr>
+                                    <th scope="col">No</th>
+                                    <th scope="col">제목</th>
+                                    <th scope="col">작성자</th>
+                                    <th scope="col">작성일</th>
+                                    <th scope="col">수락</th>
+                                </tr>
+                                </thead>
+                                <tbody id="tradeOfferList">
+                                </tbody>
+                            </table>
+                            <!-- End Table with stripped rows -->
+
+                            <div class="pagination-container">
+                                <ul class="pagination"></ul>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+
+        </div>
+    </div>
+</section>
+
+<script src="/js/commons.js"></script>
+<script>
+    $(document).ready(function () {
+        fn_init();
+    });
+    function fn_init() {
+        fn_setEvent();
+        fn_setTradeInfo();
+        fn_getTradeOfferList(0);
+    }
+
+    function fn_setEvent() {
+        $('#infoPageButton').click(function () {
+            authorize('/trade/tradeInfo.html?tradeId=' + param.tradeId+'&nickname='+param.nickname+'&tradeTitle='+param.tradeTitle);
+        });
+    }
+    function fn_setTradeInfo() {
+        $('#ownerTradeTitle').text(param.tradeTitle)
+        $('#ownerNickname').text(param.nickname)
+    }
+
+    function fn_getTradeOfferList(pageNo) {
+        $('#tradeOfferList').empty();
+
+        var paramJson = {
+            "pageNo": pageNo,
+            "tradeId": param.tradeId,
+            "nickname": param.nickname,
+            "tradeTitle": param.tradeTitle
+        };
+
+        // JSON 데이터를 가져오는 비동기 요청
+        $.ajax({
+            url: '/api/v1/trade-offers?'+ $.param(paramJson),
+            method: 'GET',
+            dataType: 'json',
+            headers: {
+                'Authorization': 'Bearer ' + localStorage.getItem("accessToken")
+            },
+            contentType: 'application/json',
+            success: function (data) {
+                console.log(data);
+                var tradeOffers = data.tradeOffers.content;
+                if (tradeOffers) {
+                    tradeOffers.forEach(function (tradeOffer) {
+                        var tradeOfferItem = '<tr class="trade-offer-item table-list" data-trade-offer-id="' + tradeOffer.id + '">' +
+                            '<th scope="row">' + tradeOffer.id + '</th>' +
+                            '<td>' + tradeOffer.title + '</td>' +
+                            '<td>' + tradeOffer.createdBy + '</td>' +
+                            '<td>' + tradeOffer.createdDate + '</td>' +
+                            '<td>' + '<button class="btn btn-primary" onclick="fn_acceptTradeOffer(' + tradeOffer.id + ')">수락</button>' + '</td>' +
+                            '</tr>';
+                        $('#tradeOfferList').append(tradeOfferItem);
+                    });
+                }
+
+                // 페이지네이션 처리
+                var totalPages = data.tradeOffers.totalPages;
+                var currentPage = data.tradeOffers.number;
+                updatePagination(currentPage, totalPages);
+
+                $('.trade-offer-item').click(function () {
+                    var json = {
+                        "tradeId" : param.tradeId,
+                        "tradeOfferId" : $(this).data('trade-offer-id'),
+                        "tradeTitle" : param.tradeTitle,
+                        "nickname" : param.nickname
+                    }
+                    authorize('/tradeOffer/tradeOfferInfo.html?tradeOfferId='+json.tradeOfferId+"&tradeTitle="+json.tradeTitle+"&nickname="+json.nickname+"&tradeId="+json.tradeId);
+                });
+            },
+            error: function () {
+                console.log('fail : trade 목록 조회');
+            }
+        });
+    }
+
+    function fn_acceptTradeOffer(tradeOfferId) {
+        $.ajax({
+            url: '/api/v1/trade-offers/'+tradeOfferId+'/accept',
+            method: 'PUT',
+            dataType: 'json',
+            headers: {
+                'Authorization': 'Bearer ' + localStorage.getItem("accessToken")
+            },
+            contentType: 'application/json',
+            success: function (data) {
+                alert("교환 요청을 수락하였습니다.");
+                authorize('/trade/tradeList.html');
+            },
+            error: function () {
+                console.log('fail : trade offer 수락');
+            }
+        });
+    }
+
+    function updatePagination(currentPage, totalPages) {
+        // Pagination 부분 업데이트
+        var paginationContainer = $('.pagination-container ul');
+        paginationContainer.empty();
+
+        var pagesToShow = 10; // 한 번에 보여질 페이지 수
+        var startPage = Math.max(1, currentPage+1 - Math.floor(pagesToShow / 2));
+        var endPage = Math.min(totalPages, startPage + pagesToShow - 1);
+
+        // 이전 버튼
+        paginationContainer.append(
+            '<li class="page-item ' + ((currentPage+1) === 1 ? 'disabled' : '') + '">' +
+            '<a class="page-link" onclick="fn_getTradeOfferList(' + ((currentPage+1) - 1) + ')">«</a>' +
+            '</li>'
+        );
+
+        for (var i = startPage; i <= endPage; i++) {
+            var pageItem =
+                '<li class="page-item ' + (i === (currentPage+1) ? 'active' : '') + '">' +
+                '<a class="page-link" onclick="fn_getTradeOfferList(' + i + ')">' + i + '</a>' +
+                '</li>';
+            paginationContainer.append(pageItem);
+        }
+
+        // 다음 버튼
+        paginationContainer.append(
+            '<li class="page-item ' + ((currentPage+1) === totalPages ? 'disabled' : '') + '">' +
+            '<a class="page-link" onclick="fn_getTradeOfferList(' + ((currentPage+1) + 1) + ')">»</a>' +
+            '</li>'
+        );
+    }
+</script>
+


### PR DESCRIPTION
* querydsl을 사용하여 기존에 member과 trade로 나누어 데이터를 불러오는 로직을 리팩토링
* 기존 `resources/static/trade` 디렉토리 안의 `tradeRequestForm.html`을 `resources/static/tradeOffer` 디렉토리의 `tradeCreateForm.html`로 변경
* tradeOffer 와 관련된 `tradeInfo.html`, `tradeList.html`  화면페이지 추가