### PR TITLE
feat : 로그아웃 api 구현, 에러 페이지 연결

### DIFF
--- a/src/main/java/kr/kernel360/anabada/domain/auth/api/AuthController.java
+++ b/src/main/java/kr/kernel360/anabada/domain/auth/api/AuthController.java
@@ -2,6 +2,7 @@ package kr.kernel360.anabada.domain.auth.api;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -41,15 +42,15 @@ public class AuthController {
 	}
 
 	@PostMapping("/v1/auth/isEmailUnique")
-	public ResponseEntity isEmailUnique(@RequestBody SignUpRequest signUpRequest) {
+	public ResponseEntity<Void> isEmailUnique(@RequestBody SignUpRequest signUpRequest) {
 		authService.isEmailUnique(signUpRequest.getEmail());
-		return ResponseEntity.ok().build();
+		return ResponseEntity.noContent().build();
 	}
 
 	@PostMapping("/v1/auth/isNicknameUnique")
-	public ResponseEntity isNicknameUnique(@RequestBody SignUpRequest signUpRequest) {
+	public ResponseEntity<Void> isNicknameUnique(@RequestBody SignUpRequest signUpRequest) {
 		authService.isNickname(signUpRequest.getNickname());
-		return ResponseEntity.ok().build();
+		return ResponseEntity.noContent().build();
 	}
 
 	@PostMapping("/v1/auth/signUp")
@@ -58,7 +59,6 @@ public class AuthController {
 		URI uri = URI.create("/api//v1/auth/signUp" + savedMemberId);
 		return ResponseEntity.created(uri).build();
 	}
-
 
 	@GetMapping("/v1/auth/callback")
 	public KakaoMemberResponse getKakaoMember(@RequestParam("code") String code) {
@@ -74,5 +74,11 @@ public class AuthController {
 	public ResponseEntity<TokenDto> reissueAccessToken(@RequestBody TokenDto requestTokenDto) {
 		TokenDto responseTokenDto = authService.reissueAccessToken(requestTokenDto);
 		return ResponseEntity.ok().body(responseTokenDto);
+	}
+
+	@PostMapping("/v1/auth/logout")
+	public ResponseEntity<Void> logout(@RequestBody Map<String,String> map) {
+		authService.logout(map.get("refreshToken"));
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/kr/kernel360/anabada/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/kernel360/anabada/domain/auth/service/AuthService.java
@@ -77,4 +77,7 @@ public class AuthService {
 		return tokenProvider.reissueToken(requestTokenDto);
 	}
 
+	public void logout(String refreshToken) {
+		tokenProvider.removeRedisRefreshToken(refreshToken);
+	}
 }

--- a/src/main/java/kr/kernel360/anabada/global/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/kr/kernel360/anabada/global/jwt/JwtAccessDeniedHandler.java
@@ -18,6 +18,6 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
 	@Override
 	public void handle(HttpServletRequest request, HttpServletResponse response,
 		AccessDeniedException accessDeniedException) throws IOException, ServletException {
-		response.sendError(HttpServletResponse.SC_FORBIDDEN);
+		response.sendRedirect("/error/pages-error-403.html");
 	}
 }

--- a/src/main/java/kr/kernel360/anabada/global/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/kr/kernel360/anabada/global/jwt/JwtAuthenticationEntryPoint.java
@@ -18,6 +18,6 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 	@Override
 	public void commence(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException authException) throws IOException, ServletException {
-		response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+		response.sendRedirect("/error/pages-error-404.html");
 	}
 }

--- a/src/main/java/kr/kernel360/anabada/global/jwt/TokenProvider.java
+++ b/src/main/java/kr/kernel360/anabada/global/jwt/TokenProvider.java
@@ -211,7 +211,7 @@ public class TokenProvider implements InitializingBean {
 		}
 	}
 
-	private void removeRedisRefreshToken(String refreshToken) {
+	public void removeRedisRefreshToken(String refreshToken) {
 		redisTemplate.opsForValue().getOperations().delete("refreshToken:" + refreshToken);
 	}
 

--- a/src/main/resources/static/error/pages-error-403.html
+++ b/src/main/resources/static/error/pages-error-403.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta content="width=device-width, initial-scale=1.0" name="viewport">
+
+  <title>Pages / Not Found 403 - NiceAdmin Bootstrap Template</title>
+  <meta content="" name="description">
+  <meta content="" name="keywords">
+
+  <!-- Favicons -->
+  <link href="/assets/img/favicon.png" rel="icon">
+  <link href="/assets/img/apple-touch-icon.png" rel="apple-touch-icon">
+
+  <!-- Google Fonts -->
+  <link href="https://fonts.gstatic.com" rel="preconnect">
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i|Nunito:300,300i,400,400i,600,600i,700,700i|Poppins:300,300i,400,400i,500,500i,600,600i,700,700i" rel="stylesheet">
+
+  <!-- Vendor CSS Files -->
+  <link href="/assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+  <link href="/assets/vendor/bootstrap-icons/bootstrap-icons.css" rel="stylesheet">
+  <link href="/assets/vendor/boxicons/css/boxicons.min.css" rel="stylesheet">
+  <link href="/assets/vendor/quill/quill.snow.css" rel="stylesheet">
+  <link href="/assets/vendor/quill/quill.bubble.css" rel="stylesheet">
+  <link href="/assets/vendor/remixicon/remixicon.css" rel="stylesheet">
+  <link href="/assets/vendor/simple-datatables/style.css" rel="stylesheet">
+
+  <!-- Template Main CSS File -->
+  <link href="/assets/css/style.css" rel="stylesheet">
+
+  <!-- =======================================================
+  * Template Name: NiceAdmin
+  * Updated: Sep 18 2023 with Bootstrap v5.3.2
+  * Template URL: https://bootstrapmade.com/nice-admin-bootstrap-admin-html-template/
+  * Author: BootstrapMade.com
+  * License: https://bootstrapmade.com/license/
+  ======================================================== -->
+</head>
+
+<body>
+
+  <main>
+    <div class="container">
+
+      <section class="section error-404 min-vh-100 d-flex flex-column align-items-center justify-content-center">
+        <h1>403</h1>
+        <h2>접근할 수 없는 페이지입니다.</h2>
+        <a class="btn" href="/">홈으로</a>
+        <img src="/assets/img/not-found.svg" class="img-fluid py-5" alt="Page Not Found">
+      </section>
+
+    </div>
+  </main><!-- End #main -->
+
+  <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="bi bi-arrow-up-short"></i></a>
+
+  <!-- Vendor JS Files -->
+  <script src="/assets/vendor/apexcharts/apexcharts.min.js"></script>
+  <script src="/assets/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="/assets/vendor/chart.js/chart.umd.js"></script>
+  <script src="/assets/vendor/echarts/echarts.min.js"></script>
+  <script src="/assets/vendor/quill/quill.min.js"></script>
+  <script src="/assets/vendor/simple-datatables/simple-datatables.js"></script>
+  <script src="/assets/vendor/tinymce/tinymce.min.js"></script>
+  <script src="/assets/vendor/php-email-form/validate.js"></script>
+
+  <!-- Template Main JS File -->
+  <script src="/assets/js/main.js"></script>
+
+</body>
+
+</html>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -34,11 +34,12 @@
         var param = {};
         $(document).ready(function () {
             fn_init();
-            $('main[content="container"]').empty();
-            loadHtmlAndExecuteScript("/main.html", param);
         });
 
         function fn_init() {
+            $('main[content="container"]').empty();
+            loadHtmlAndExecuteScript("/main.html", param);
+
             if (null != localStorage.getItem("accessToken")) {
                 fn_getMemberInfo();
                 fn_getLocationInfo();
@@ -226,8 +227,27 @@
         }
 
         function fn_logout() {
-            localStorage.clear();
-            window.location.href = "/";
+            var paramJson = {
+                refreshToken: localStorage.getItem("refreshToken")
+            }
+            $.ajax({
+                url: '/api/v1/auth/logout',
+                method: 'POST',
+                dataType: 'json',
+                data: JSON.stringify(paramJson),
+                contentType: 'application/json',
+                headers: {
+                    'Authorization': 'Bearer ' + localStorage.getItem("accessToken") // 헤더에 토큰 추가
+                },
+                cache: false,  // 이 부분을 추가해보세요
+                success : function (data) {
+                    localStorage.clear();
+                    window.location.href = "/";
+                },
+                error: function (data) {
+                    console.error("fail : 로그아웃", data);
+                }
+            });
         }
     </script>
 </head>


### PR DESCRIPTION
- 로그아웃 api 호출 시 레디스의 리플래시 토큰을 제거하도록 구현하였습니다.
- 유효한 자격증명을 제공하지 않고 접근할 때 401 에러가 발생하지만 사용자 측면에서 404 페이지로 이동하도록 구현했습니다. 
- 필요한 권한이 존재하지 않을 경우 403 페이지로 이동하도록 수정하였습니다.