### PR TITLE
bug : 소셜로그인 회원가입

### DIFF
--- a/src/main/java/kr/kernel360/anabada/domain/oauth2/OAuthAttributes.java
+++ b/src/main/java/kr/kernel360/anabada/domain/oauth2/OAuthAttributes.java
@@ -6,6 +6,7 @@ import kr.kernel360.anabada.domain.member.entity.Member;
 import kr.kernel360.anabada.domain.oauth2.memberinfo.KakaoOAuth2MemberInfo;
 import kr.kernel360.anabada.domain.oauth2.memberinfo.OAuth2MemberInfo;
 import kr.kernel360.anabada.global.commons.domain.SocialProvider;
+import kr.kernel360.anabada.global.utils.AgeGroupParser;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -45,6 +46,7 @@ public class OAuthAttributes {
 			.nickname(socialProvider.getDescription() + oAuth2MemberInfo.getNickname())
 			.gender(oAuth2MemberInfo.getGender())
 			.birth(oAuth2MemberInfo.getBirth())
+			.ageGroup(AgeGroupParser.birthToAgeGroup(oAuth2MemberInfo.getBirth()))
 			.build();
 	}
 }

--- a/src/main/resources/static/auth/login.html
+++ b/src/main/resources/static/auth/login.html
@@ -46,7 +46,7 @@
         }
 
         function fn_memberAlreadyExist_alert() {
-            alert("회원가입한 계정으로 로그인해주세요.");
+            alert("일반 회원가입으로 가입한 이메일이 존재합니다. \n일반 로그인으로 로그인 해주세요.");
         }
 
         function fn_setEvent() {


### PR DESCRIPTION
- 소셜로그인 회원가입 시 일반 회원가입한 이메일과 동일하다면 화면에 나타나는 알림메시지를 수정하였습니다.
  -  "회원가입한 계정으로 로그인해주세요."  ➡️  "일반 회원가입으로 가입한 이메일이 존재합니다. 일반 로그인으로 로그인 해주세요."

- 소셜로그인 회원가입중 ageGroup값이 누락되어 회원가입 되지 않는 현상을 수정하였습니다.