### PR TITLE
fix : 카카오 로그인 유저 닉네임 생성 방법 변경 및 client-id, secret 교체

### DIFF
--- a/src/main/java/kr/kernel360/anabada/domain/oauth2/OAuthAttributes.java
+++ b/src/main/java/kr/kernel360/anabada/domain/oauth2/OAuthAttributes.java
@@ -43,7 +43,7 @@ public class OAuthAttributes {
 			.email(oAuth2MemberInfo.getEmail())
 			.authorities("ROLE_USER")
 			.accountStatus(true)
-			.nickname(socialProvider.getDescription() + oAuth2MemberInfo.getNickname())
+			.nickname(oAuth2MemberInfo.getNickname() + oAuth2MemberInfo.getId())
 			.gender(oAuth2MemberInfo.getGender())
 			.birth(oAuth2MemberInfo.getBirth())
 			.ageGroup(AgeGroupParser.birthToAgeGroup(oAuth2MemberInfo.getBirth()))


### PR DESCRIPTION
* main application의 client - secret, id 를 교체했습니다.